### PR TITLE
Fix package add command in docs

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -12,7 +12,7 @@ ${TeamId}
 The Honeycomb AspNet core integration is setup in the package `Honeycomb.AspNetCore` On nuget.
 
 ```cmd
-dotnet package add Honeycomb.AspNetCore
+dotnet add package Honeycomb.AspNetCore
 ```
 
 You can also add the above package through visual studio.


### PR DESCRIPTION
This was inverted

https://docs.microsoft.com/en-us/dotnet/core/tools/dotnet-add-package